### PR TITLE
fix for two items in Issue 4 (PHP)

### DIFF
--- a/Solarized (dark).tmTheme
+++ b/Solarized (dark).tmTheme
@@ -1112,6 +1112,17 @@
 		</dict>
 		<dict>
 			<key>name</key>
+			<string>PHP: Semicolon</string>
+			<key>scope</key>
+			<string>punctuation.terminator.expression.php</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#839496</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
 			<string>PHP: Inherited Class</string>
 			<key>scope</key>
 			<string>meta.other.inherited-class.php</string>


### PR DESCRIPTION
This fixes class names and semicolons in the Dark PHP theme. These should be two separate pull requests but I'm not that good at GitHub yet, sorry. 
