### PR TITLE
Set background color to correct Solarize hex value. Fixes issue #20

### DIFF
--- a/Solarized (dark).tmTheme
+++ b/Solarized (dark).tmTheme
@@ -10,17 +10,17 @@
 			<key>settings</key>
 			<dict>
 				<key>background</key>
-				<string>#042029</string>
+				<string>#002B36</string>
 				<key>caret</key>
 				<string>#819090</string>
 				<key>foreground</key>
 				<string>#839496</string>
 				<key>invisibles</key>
-				<string>#0A2933</string>
+				<string>#073642</string>
 				<key>lineHighlight</key>
-				<string>#0A2933</string>
+				<string>#073642</string>
 				<key>selection</key>
-				<string>#0A2933</string>
+				<string>#073642</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Like the commit says... minor changes to get the hex values set to the standard-issue Solarize spec. Note that I haven't checked for issues with the "light" version of the theme since I haven't used it.
