### PR TITLE
Changed all colors to standard Solarized colors.

### DIFF
--- a/Solarized (dark).tmTheme
+++ b/Solarized (dark).tmTheme
@@ -12,7 +12,7 @@
 				<key>background</key>
 				<string>#002B36</string>
 				<key>caret</key>
-				<string>#819090</string>
+				<string>#839496</string>
 				<key>foreground</key>
 				<string>#839496</string>
 				<key>invisibles</key>
@@ -66,7 +66,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#D30102</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -112,7 +112,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#738A05</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -156,7 +156,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#D30102</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -178,7 +178,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#D30102</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -262,7 +262,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#D30102</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -330,7 +330,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -341,7 +341,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#C60000</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -354,7 +354,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -365,7 +365,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#D01F1E</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -378,7 +378,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#536871</string>
+				<string>#586E75</string>
 			</dict>
 		</dict>
 		<dict>
@@ -389,7 +389,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#5A74CF</string>
+				<string>#6C71C4</string>
 			</dict>
 		</dict>
 		<dict>
@@ -402,7 +402,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -415,7 +415,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -426,7 +426,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#D01F1E</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -437,7 +437,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -448,7 +448,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#738A13</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -461,7 +461,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#536871</string>
+				<string>#586E75</string>
 			</dict>
 		</dict>
 		<dict>
@@ -487,7 +487,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -511,7 +511,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -524,7 +524,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -546,7 +546,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -603,7 +603,7 @@
 				<key>fontStyle</key>
 				<string>italic</string>
 				<key>foreground</key>
-				<string>#899090</string>
+				<string>#839496</string>
 			</dict>
 		</dict>
 		<dict>
@@ -640,7 +640,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -653,7 +653,7 @@
 				<key>fontStyle</key>
 				<string>bold</string>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -666,7 +666,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#708284</string>
+				<string>#657B83</string>
 			</dict>
 		</dict>
 		<dict>
@@ -677,7 +677,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#708284</string>
+				<string>#657B83</string>
 			</dict>
 		</dict>
 		<dict>
@@ -690,7 +690,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -749,7 +749,7 @@
 				<key>fontStyle</key>
 				<string>italic</string>
 				<key>foreground</key>
-				<string>#819090</string>
+				<string>#839496</string>
 			</dict>
 		</dict>
 		<dict>
@@ -773,7 +773,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#708284</string>
+				<string>#657B83</string>
 			</dict>
 		</dict>
 		<dict>
@@ -784,7 +784,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#469186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -808,7 +808,7 @@
 				<key>fontStyle</key>
 				<string>bold</string>
 				<key>foreground</key>
-				<string>#738A05</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -819,7 +819,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -832,7 +832,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -845,7 +845,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#748B00</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -858,7 +858,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -869,7 +869,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -880,7 +880,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -893,7 +893,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -906,7 +906,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -917,7 +917,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#D01F1E</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -928,7 +928,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -939,7 +939,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -952,7 +952,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#819090</string>
+				<string>#839496</string>
 			</dict>
 		</dict>
 		<dict>
@@ -965,7 +965,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -998,7 +998,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#D31E1E</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1009,7 +1009,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#536871</string>
+				<string>#586E75</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1022,7 +1022,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1033,7 +1033,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1044,7 +1044,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#D31E1E</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1055,7 +1055,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1090,7 +1090,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#899090</string>
+				<string>#839496</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1101,7 +1101,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1131,7 +1131,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#536871</string>
+				<string>#586E75</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1142,7 +1142,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1153,7 +1153,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#899090</string>
+				<string>#839496</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1164,7 +1164,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1188,7 +1188,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#899090</string>
+				<string>#839496</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1199,7 +1199,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#BD3613</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1210,7 +1210,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1223,7 +1223,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1236,7 +1236,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#BB3700</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1249,7 +1249,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#BB3700</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1262,7 +1262,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#BB3700</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1275,7 +1275,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1288,7 +1288,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#536871</string>
+				<string>#586E75</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1301,7 +1301,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1314,7 +1314,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1325,11 +1325,11 @@
 			<key>settings</key>
 			<dict>
 				<key>background</key>
-				<string>#A57706</string>
+				<string>#B58900</string>
 				<key>fontStyle</key>
 				<string>italic</string>
 				<key>foreground</key>
-				<string>#E0EDDD</string>
+				<string>#EEE8D5</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1340,11 +1340,11 @@
 			<key>settings</key>
 			<dict>
 				<key>background</key>
-				<string>#EAE3CA</string>
+				<string>#EEE8D5</string>
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#D3201F</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1355,11 +1355,11 @@
 			<key>settings</key>
 			<dict>
 				<key>background</key>
-				<string>#EAE3CA</string>
+				<string>#EEE8D5</string>
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#BF3904</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1370,9 +1370,9 @@
 			<key>settings</key>
 			<dict>
 				<key>background</key>
-				<string>#EAE3CA</string>
+				<string>#EEE8D5</string>
 				<key>foreground</key>
-				<string>#219186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1383,9 +1383,9 @@
 			<key>settings</key>
 			<dict>
 				<key>background</key>
-				<string>#A57706</string>
+				<string>#B58900</string>
 				<key>foreground</key>
-				<string>#E0EDDD</string>
+				<string>#EEE8D5</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1396,7 +1396,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1407,7 +1407,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1420,7 +1420,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#D3201F</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1431,7 +1431,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1444,7 +1444,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#B81D1C</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1457,7 +1457,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57705</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1470,7 +1470,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57705</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1483,7 +1483,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1496,7 +1496,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#D01F1E</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1509,7 +1509,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1522,7 +1522,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1535,7 +1535,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#D3201F</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1548,7 +1548,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1561,7 +1561,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#D01F1E</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1574,7 +1574,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#748B00</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1587,7 +1587,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1600,7 +1600,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1624,7 +1624,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1637,7 +1637,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#748B00</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1648,7 +1648,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1659,7 +1659,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1670,7 +1670,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1681,7 +1681,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1707,7 +1707,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#536871</string>
+				<string>#586E75</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1720,7 +1720,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#748B00</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1733,7 +1733,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#536871</string>
+				<string>#586E75</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1746,7 +1746,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#CD1E1D</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1770,7 +1770,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1796,7 +1796,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1809,7 +1809,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#536871</string>
+				<string>#586E75</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1822,7 +1822,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#536871</string>
+				<string>#586E75</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1928,7 +1928,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#D3201F</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>

--- a/Solarized (light).tmTheme
+++ b/Solarized (light).tmTheme
@@ -12,11 +12,11 @@
 				<key>background</key>
 				<string>#FDF6E3</string>
 				<key>caret</key>
-				<string>#000000</string>
+				<string>#002B36</string>
 				<key>foreground</key>
 				<string>#586E75</string>
 				<key>invisibles</key>
-				<string>#EAE3C9</string>
+				<string>#EEE8D5</string>
 				<key>lineHighlight</key>
 				<string>#EEE8D5</string>
 				<key>selection</key>
@@ -66,7 +66,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#D30102</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -156,7 +156,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#D30102</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -178,7 +178,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#D30102</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -262,7 +262,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#D30102</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -330,7 +330,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -341,7 +341,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#C60000</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -354,7 +354,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -365,7 +365,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#D01F1E</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -378,7 +378,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#536871</string>
+				<string>#586E75</string>
 			</dict>
 		</dict>
 		<dict>
@@ -389,7 +389,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#5A74CF</string>
+				<string>#6C71C4</string>
 			</dict>
 		</dict>
 		<dict>
@@ -402,7 +402,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -415,7 +415,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -426,7 +426,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#D01F1E</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -437,7 +437,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -448,7 +448,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#738A13</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -461,7 +461,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#536871</string>
+				<string>#586E75</string>
 			</dict>
 		</dict>
 		<dict>
@@ -487,7 +487,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -511,7 +511,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -524,7 +524,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -546,7 +546,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -603,7 +603,7 @@
 				<key>fontStyle</key>
 				<string>italic</string>
 				<key>foreground</key>
-				<string>#899090</string>
+				<string>#839496</string>
 			</dict>
     	</dict>
 		<dict>
@@ -640,7 +640,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -653,7 +653,7 @@
 				<key>fontStyle</key>
 				<string>bold</string>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -666,7 +666,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#708284</string>
+				<string>#657B83</string>
 			</dict>
 		</dict>
 		<dict>
@@ -677,7 +677,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#708284</string>
+				<string>#657B83</string>
 			</dict>
 		</dict>
 		<dict>
@@ -690,7 +690,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -749,7 +749,7 @@
 				<key>fontStyle</key>
 				<string>italic</string>
 				<key>foreground</key>
-				<string>#819090</string>
+				<string>#839496</string>
 			</dict>
 		</dict>
 		<dict>
@@ -773,7 +773,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#708284</string>
+				<string>#657B83</string>
 			</dict>
 		</dict>
 		<dict>
@@ -784,7 +784,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#469186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -808,7 +808,7 @@
 				<key>fontStyle</key>
 				<string>bold</string>
 				<key>foreground</key>
-				<string>#738A05</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -819,7 +819,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -832,7 +832,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -845,7 +845,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#748B00</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -858,7 +858,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -869,7 +869,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -880,7 +880,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -893,7 +893,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -906,7 +906,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -917,7 +917,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#D01F1E</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -928,7 +928,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -939,7 +939,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -952,7 +952,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#819090</string>
+				<string>#839496</string>
 			</dict>
 		</dict>
 		<dict>
@@ -965,7 +965,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -987,7 +987,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#D31E1E</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -998,7 +998,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#536871</string>
+				<string>#586E75</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1011,7 +1011,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1022,7 +1022,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1033,7 +1033,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#D31E1E</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1044,7 +1044,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1068,7 +1068,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#536871</string>
+				<string>#586E75</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1079,7 +1079,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#899090</string>
+				<string>#839496</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1090,7 +1090,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1109,7 +1109,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#536871</string>
+				<string>#586E75</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1120,7 +1120,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1131,7 +1131,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#899090</string>
+				<string>#839496</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1142,7 +1142,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1166,7 +1166,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#899090</string>
+				<string>#839496</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1177,7 +1177,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#BD3613</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1188,7 +1188,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1201,7 +1201,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1214,7 +1214,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#BB3700</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1227,7 +1227,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#BB3700</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1240,7 +1240,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#BB3700</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1253,7 +1253,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1266,7 +1266,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#536871</string>
+				<string>#586E75</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1279,7 +1279,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1292,7 +1292,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1303,11 +1303,11 @@
 			<key>settings</key>
 			<dict>
 				<key>background</key>
-				<string>#A57706</string>
+				<string>#B58900</string>
 				<key>fontStyle</key>
 				<string>italic</string>
 				<key>foreground</key>
-				<string>#E0EDDD</string>
+				<string>#EEE8D5</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1318,11 +1318,11 @@
 			<key>settings</key>
 			<dict>
 				<key>background</key>
-				<string>#EAE3CA</string>
+				<string>#EEE8D5</string>
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#D3201F</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1333,11 +1333,11 @@
 			<key>settings</key>
 			<dict>
 				<key>background</key>
-				<string>#EAE3CA</string>
+				<string>#EEE8D5</string>
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#BF3904</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1348,9 +1348,9 @@
 			<key>settings</key>
 			<dict>
 				<key>background</key>
-				<string>#EAE3CA</string>
+				<string>#EEE8D5</string>
 				<key>foreground</key>
-				<string>#219186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1361,9 +1361,9 @@
 			<key>settings</key>
 			<dict>
 				<key>background</key>
-				<string>#A57706</string>
+				<string>#B58900</string>
 				<key>foreground</key>
-				<string>#E0EDDD</string>
+				<string>#EEE8D5</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1374,7 +1374,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1385,7 +1385,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1398,7 +1398,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#D3201F</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1409,7 +1409,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1422,7 +1422,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#B81D1C</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1435,7 +1435,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57705</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1448,7 +1448,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57705</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1461,7 +1461,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1474,7 +1474,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#D01F1E</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1487,7 +1487,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1500,7 +1500,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1513,7 +1513,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#D3201F</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1526,7 +1526,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1539,7 +1539,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#D01F1E</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1552,7 +1552,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#748B00</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1565,7 +1565,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1578,7 +1578,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1602,7 +1602,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#269186</string>
+				<string>#2AA198</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1615,7 +1615,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#748B00</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1626,7 +1626,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1637,7 +1637,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1648,7 +1648,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1659,7 +1659,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1685,7 +1685,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#536871</string>
+				<string>#586E75</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1698,7 +1698,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#748B00</string>
+				<string>#859900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1711,7 +1711,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#536871</string>
+				<string>#586E75</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1724,7 +1724,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#CD1E1D</string>
+				<string>#DC322F</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1748,7 +1748,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#BD3800</string>
+				<string>#CB4B16</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1774,7 +1774,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#A57800</string>
+				<string>#B58900</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1787,7 +1787,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#536871</string>
+				<string>#586E75</string>
 			</dict>
 		</dict>
 		<dict>
@@ -1800,7 +1800,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#536871</string>
+				<string>#586E75</string>
 			</dict>
 		</dict>
 		<dict>
@@ -2022,7 +2022,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#6a8187</string>
+				<string>#657B83</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Here are various screen captures -- the only major concern is the red next to orange in Ruby.  Maybe Ruby just needs to switch the red or orange to a different color.
https://gist.github.com/3361667

Info for commit

base03 #002B36 - from #000000
base01 #586E75 - from #536871
base00 #657B83 - from #708284|#6a8187
base0 #839496 - from #819090|#899090
base2 #EEE8D5 - from #EAE3CA|#E0EDDD|#EAE3C9
yellow #B58900 - from #A57705|#A57706|#A57800
orange #CB4B16 - from #BB3700|#BD3613|#BD3800|#BF3904
red #DC322F - from #B81D1C|#C60000|#CD1E1D|#D01F1E|#D30102|#D31E1E|#D3201F
violet #6C71C4 - from #5A74CF
cyan #2AA198 - from #219186|#269186|#469186
green #859900 - from #738A05|#738A13|#748B00

Standard colors from the palette are
base03:    #002b36
base02:    #073642
base01:    #586e75
base00:    #657b83
base0:     #839496
base1:     #93a1a1
base2:     #eee8d5
base3:     #fdf6e3

red:       #dc322f
magenta:   #d33682
violet:    #6c71c4
blue:      #268bd2
cyan:      #2aa198
green:     #859900
