### PR TITLE
Add BG colour for embedded source

### DIFF
--- a/Solarized (dark).tmTheme
+++ b/Solarized (dark).tmTheme
@@ -20,7 +20,7 @@
 				<key>lineHighlight</key>
 				<string>#073642</string>
 				<key>selection</key>
-				<string>#073642</string>
+				<string>#EEE8D5</string>
 			</dict>
 		</dict>
 		<dict>
@@ -115,6 +115,17 @@
 				<string>#738A05</string>
 			</dict>
 		</dict>
+		<dict>
+			<key>name</key>
+			<string>Embedded Source</string>
+			<key>scope</key>
+			<string>text source</string>
+			<key>settings</key>
+			<dict>
+				<key>background</key>
+				<string>#073642</string>
+			</dict>
+		</dict>		
 		<dict>
 			<key>name</key>
 			<string>Class name</string>

--- a/Solarized (light).tmTheme
+++ b/Solarized (light).tmTheme
@@ -194,6 +194,17 @@
 		</dict>
 		<dict>
 			<key>name</key>
+			<string>Embedded Source</string>
+			<key>scope</key>
+			<string>text source</string>
+			<key>settings</key>
+			<dict>
+				<key>background</key>
+				<string>#EEE8D5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
 			<string>Inherited class</string>
 			<key>scope</key>
 			<string>entity.other.inherited-class</string>


### PR DESCRIPTION
This will slightly highlight embedded source. This is really good for differentiating PHP and JS within HTML. This is the only syntax I've tested it in.
