### PR TITLE
Replaced (most) nonstandard colors with official Solarized color values

### DIFF
--- a/Solarized (dark).tmTheme
+++ b/Solarized (dark).tmTheme
@@ -112,7 +112,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#738A05</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -448,7 +448,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#738A13</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -808,7 +808,7 @@
 				<key>fontStyle</key>
 				<string>bold</string>
 				<key>foreground</key>
-				<string>#738A05</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -819,7 +819,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -845,7 +845,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#748B00</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -869,7 +869,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -1142,7 +1142,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -1164,7 +1164,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -1574,7 +1574,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#748B00</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -1637,7 +1637,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#748B00</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -1670,7 +1670,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -1720,7 +1720,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#748B00</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>

--- a/Solarized (light).tmTheme
+++ b/Solarized (light).tmTheme
@@ -448,7 +448,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#738A13</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -808,7 +808,7 @@
 				<key>fontStyle</key>
 				<string>bold</string>
 				<key>foreground</key>
-				<string>#738A05</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -819,7 +819,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -845,7 +845,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#748B00</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -869,7 +869,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -1120,7 +1120,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -1142,7 +1142,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -1552,7 +1552,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#748B00</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -1615,7 +1615,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#748B00</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -1648,7 +1648,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#748B00</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>
@@ -1698,7 +1698,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#748B00</string><!-- (nonstandard) ~green -->
+				<string>#859900</string><!-- green -->
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
A small number of nonstandard colors remain.  These were cases where I wasn’t certain what the color affected, or situations where the color is _supposed_ to be slightly off—for example: the gutter, or the caret.

Although I can’t test these with every possible language, I’m pretty sure there shouldn’t be any issues with these changes.  As I was working on this, it seemed to me that most of the nonstandard colors were simply an ad-hoc approximation, rather than a deliberate use of “slightly off” colors for situations like the above.
