### PR TITLE
[Light] Fixes highlighting selection color for Light scheme.

### DIFF
--- a/Solarized (light).tmTheme
+++ b/Solarized (light).tmTheme
@@ -20,7 +20,7 @@
 				<key>lineHighlight</key>
 				<string>#EEE8D5</string><!-- base2 -->
 				<key>selection</key>
-				<string>#073642</string><!-- base02 -->
+				<string>#EEE8D5</string><!-- base2 -->
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Fixes issue #43.

Light scheme was using base02 color for highlighting, when Solarized specs clearly state that it is base2 the one that must be used for this purpose.

![screen shot 2013-11-16 at 11 07 40 pm](https://f.cloud.github.com/assets/1840284/1557332/01c2be34-4f10-11e3-80b1-b318bbb95d06.png)
